### PR TITLE
Use custom User-Agent.

### DIFF
--- a/src/app/proxerapi/page_utils.js
+++ b/src/app/proxerapi/page_utils.js
@@ -1,6 +1,31 @@
 module.exports = {
-    headers: {
-        'User-Agent': 'Chrome/' + process.versions['chrome'] + ' Electron/' + process.versions['electron']
+    getHeaders: function(version, customDisabled, platform, release) {
+        var header;
+        if(customDisabled) {
+            var osInfo;
+            switch(platform) {
+                case 'darwin':
+                    osInfo = 'Macintosh; Intel Mac OS X ';
+                    osInfo += release.replace('.', '_');
+                    break;
+                case 'linux':
+                    osInfo = 'X11; Linux x86_64';
+                    break;
+                case 'win32':
+                    osInfo = 'Windows NT ' + release.substr(0, 3) + '; WOW64';
+                    break;
+            }
+
+            header = 'Mozilla/5.0 (' + osInfo + ') ' +
+                'AppleWebKit/537.36 (KHTML, like Gecko) Chrome/' + process.versions['chrome'] + ' ' +
+                'Safari/537.36';
+        } else {
+            header = 'Chrome/' + process.versions['chrome'] + ' Electron/' + process.versions['electron'] + ' Proxtop/' + version
+        }
+
+        return {
+            'User-Agent': header
+        };
     },
 
     checkUnauthorized: function(page) {

--- a/src/app/proxtop.js
+++ b/src/app/proxtop.js
@@ -12,7 +12,7 @@ function Proxtop(app, window_manager, updater, options) {
     this.info = options.info;
     this.updater = updater;
     this.api = new API(settings);
-    this.proxer_api = new ProxerAPI(this,path.join(this.app_dir, "cookies.json"));
+    this.proxer_api = new ProxerAPI(this, path.join(this.app_dir, "cookies.json"));
 }
 
 Proxtop.prototype.start = function() {
@@ -37,6 +37,10 @@ Proxtop.prototype.notifyWindow = function() {
 
 Proxtop.prototype.notifyUpdate = function(release) {
     this.notifyWindow('update', release);
+};
+
+Proxtop.prototype.getSettings = function() {
+    return settings;
 };
 
 Proxtop.prototype.setupApp = function() {

--- a/src/app/settings.js
+++ b/src/app/settings.js
@@ -27,7 +27,8 @@ var DEFAULTS = {
     },
     DEFAULT_GENERAL_SETTINGS: {
         language: 'de',
-        type: 'general'
+        type: 'general',
+        disable_user_agent: false
     },
     DEFAULT_MANGA_SETTINGS: {
         type: 'manga',

--- a/src/ui/locale/locale-de.json
+++ b/src/ui/locale/locale-de.json
@@ -64,7 +64,8 @@
         "LANGUAGE": "Sprache",
         "EN": "Englisch",
         "DE": "Deutsch"
-      }
+      },
+      "DISABLE_USER_AGENT": "Universalen User-Agent verwenden"
     }
   },
   "MESSAGES": {

--- a/src/ui/locale/locale-en.json
+++ b/src/ui/locale/locale-en.json
@@ -64,7 +64,8 @@
         "LANGUAGE": "Language",
         "EN": "English",
         "DE": "German"
-      }
+      },
+      "DISABLE_USER_AGENT": "Use universal user agent"
     }
   },
   "MESSAGES": {

--- a/src/ui/settings/settings.controller.js
+++ b/src/ui/settings/settings.controller.js
@@ -1,4 +1,4 @@
-angular.module('proxtop').controller('SettingsController', ['$scope', 'settings', '$translate', function($scope, settings, $translate) {
+angular.module('proxtop').controller('SettingsController', ['$scope', 'settings', '$translate', 'ipc', function($scope, settings, $translate, ipc) {
     $scope.providers = [
         "Proxer-Stream",
         "Dailymotion",
@@ -23,12 +23,17 @@ angular.module('proxtop').controller('SettingsController', ['$scope', 'settings'
         watchlist: settings.get('watchlist'),
         general: settings.get('general')
     };
+    $scope.has_toggled = false;
 
     $scope.$watch(function(scope) {
         return scope.settings.general.language;
     }, function(newValue) {
         $translate.use(newValue);
     });
+
+    $scope.toggleRequestUpdate = function() {
+        $scope.has_toggled = !$scope.has_toggled;
+    };
 
     $scope.saveSettings = function() {
         settings.set('account', {
@@ -43,5 +48,10 @@ angular.module('proxtop').controller('SettingsController', ['$scope', 'settings'
         settings.set('anime', $scope.settings.anime);
         settings.set('watchlist', $scope.settings.watchlist);
         settings.set('general', $scope.settings.general);
+
+        if($scope.has_toggled) {
+            ipc.send('reload-request');
+            $scope.has_toggled = false;
+        }
     };
 }]);

--- a/src/ui/settings/settings.html
+++ b/src/ui/settings/settings.html
@@ -18,6 +18,7 @@
                     <md-radio-button value="de">{{ 'SETTINGS.GENERAL.LANGUAGE.DE' | translate }}</md-radio-button>
                     <md-radio-button value="en">{{ 'SETTINGS.GENERAL.LANGUAGE.EN' | translate }}</md-radio-button>
                 </md-radio-group>
+                <md-checkbox ng-model="settings.general.disable_user_agent" aira-label="Custom Header?" ng-change="toggleRequestUpdate()">{{ 'SETTINGS.GENERAL.DISABLE_USER_AGENT' | translate }}</md-checkbox>
             </md-card-content>
         </md-card>
         <md-card>

--- a/test/src/page_utils.test.js
+++ b/test/src/page_utils.test.js
@@ -1,0 +1,27 @@
+var utils = require('../../src/app/proxerapi/page_utils');
+var os = require('os');
+
+describe('page_utils#getHeaders', function() {
+    it('should get the correct user agent', function() {
+        utils.getHeaders('1.1.0').should.have.property('User-Agent');
+        utils.getHeaders('1.1.0')['User-Agent'].should.include('Proxtop/1.1.0');
+    });
+
+    it('should get the default if the custom is disabled', function() {
+        utils.getHeaders('1.1.0', true, os.platform(), os.release()).should.have.property('User-Agent');
+        utils.getHeaders('1.1.0', true, os.platform(), os.release())['User-Agent'].should.not.include('Proxtop');
+        utils.getHeaders('1.1.0', true, os.platform(), os.release())['User-Agent'].should.include('Chrome');
+    });
+
+    it('should include the current OS', function() {
+        utils.getHeaders('1.1.0', true, 'win32', '6.1.1').should.have.property('User-Agent');
+        utils.getHeaders('1.1.0', true, 'win32', '6.1.1')['User-Agent'].should.include('Windows NT 6.1');
+        utils.getHeaders('1.1.0', true, 'win32', '6.1.1')['User-Agent'].should.not.include('Linux');
+        utils.getHeaders('1.1.0', true, 'win32', '6.1.1')['User-Agent'].should.not.include('Mac');
+
+        utils.getHeaders('1.1.0', true, 'darwin', '10_11_3').should.have.property('User-Agent');
+        utils.getHeaders('1.1.0', true, 'darwin', '10_11_3')['User-Agent'].should.include('Mac OS X 10_11_3');
+        utils.getHeaders('1.1.0', true, 'darwin', '10_11_3')['User-Agent'].should.not.include('Linux');
+        utils.getHeaders('1.1.0', true, 'darwin', '10_11_3')['User-Agent'].should.not.include('Windows');
+    });
+});


### PR DESCRIPTION
I'm opening this not because I want to add it yet, but I want to bring this to peoples attention.

So what is the idea behind this?

I want to give the proxer team the possibility of easily identifying requests coming from this application. What they'd do with it, is out of my hand, but I'm always for giving options to people. In this case it's not the actual users, but the ones providing the content. If they decide to track it or completely block it, which would be sad, then so be it. But that's their decision, not mine. (I don't think either will be the case, given how much I know from them)

I want to also allow people to disable this and just use a generic, but fitting, User-Agent (similar to what Chrome would send normally. This currently isn't the case either). Until this has not been finished, I won't be merging this into master.

Now to what I'm asking from other people:
- Do you think this is a good idea in general?
- Would you make any other changes concerning the User-Agent?