### PR TITLE
Update desktop entry

### DIFF
--- a/build/proxtop.desktop
+++ b/build/proxtop.desktop
@@ -2,6 +2,9 @@
 Version=1.0
 Type=Application
 Name=Proxtop
+GenericName=Proxer
+Comment=A desktop client for the german anime site proxer.me
+Categories=Network;Application;
 Path=/opt/proxtop
 Exec=proxtop
 Icon=proxtop


### PR DESCRIPTION
Proxtop was shown in the "others" category. I think it belongs along with skype, Hexchat, etc. to "Network".
 
Add "Categories", "GenericName" and "Comment"